### PR TITLE
Added UseProtoNames functionality

### DIFF
--- a/nrpc.go
+++ b/nrpc.go
@@ -23,6 +23,9 @@ type ContextKey int
 // ErrStreamInvalidMsgCount is when a stream reply gets a wrong number of messages
 var ErrStreamInvalidMsgCount = errors.New("Stream reply received an incorrect number of messages")
 
+// Set the UseProtoNames flag in protojson MarshalOptions
+var UseProtoNames = false
+
 //go:generate protoc --go_out=. --go_opt=paths=source_relative nrpc.proto
 
 type NatsConn interface {
@@ -97,7 +100,7 @@ func Marshal(encoding string, msg proto.Message) ([]byte, error) {
 	case "protobuf":
 		return proto.Marshal(msg)
 	case "json":
-		return jsonpb.Marshal(msg)
+		return jsonpb.MarshalOptions{UseProtoNames: UseProtoNames}.Marshal(msg)
 	default:
 		return nil, errors.New("Invalid encoding: " + encoding)
 	}

--- a/protoc-gen-nrpc/main.go
+++ b/protoc-gen-nrpc/main.go
@@ -247,6 +247,7 @@ func getPkgImportName(goPkg string) string {
 
 var pluginPrometheus bool
 var pathsSourceRelative bool
+var useProtoNames bool
 
 var funcMap = template.FuncMap{
 	"GoPackageName": func(fd *descriptor.FileDescriptorProto) string {
@@ -376,6 +377,9 @@ var funcMap = template.FuncMap{
 	"Prometheus": func() bool {
 		return pluginPrometheus
 	},
+	"UseProtoNames": func() bool {
+		return useProtoNames
+	},
 	"GetResultType": getResultType,
 	"GoType": func(pbType string) string {
 		goPkg, goType := getGoType(pbType)
@@ -426,6 +430,10 @@ func main() {
 				default:
 					log.Fatalf("invalid plugin: %s", plugin)
 				}
+			}
+		case "use_proto_names":
+			if value == "true" {
+				useProtoNames = true
 			}
 		case "paths":
 			if value == "source_relative" {

--- a/protoc-gen-nrpc/tmpl.go
+++ b/protoc-gen-nrpc/tmpl.go
@@ -24,6 +24,10 @@ import (
 	"github.com/nats-rpc/nrpc"
 )
 
+{{- if UseProtoNames}}
+nrcp.UseProtoNames = true
+{{- end }}
+
 {{- range .Service}}
 
 // {{.GetName}}Server is the interface that providers of the service


### PR DESCRIPTION
…Allows the preservation of the proto snake_case names rather than the lowerCamelCase that is used by default when marshaling to json. I wasn't exactly sure where you wanted me to set the flag for this to get passed on to the marshaler so I added the nrpc.UseProtoNames bool. Let me know if you would like it somewhere else and I will make changes accordingly. 

I also added the optional use_proto_names option that can get passed through via protoc args. (like prometheus)