### PR TITLE
Use pointer args to avoid copying protobuf messages

### DIFF
--- a/examples/helloworld/greeter_client/main.go
+++ b/examples/helloworld/greeter_client/main.go
@@ -29,7 +29,7 @@ func main() {
 	cli := helloworld.NewGreeterClient(nc)
 
 	// Contact the server and print out its response.
-	resp, err := cli.SayHello(helloworld.HelloRequest{Name: "world"})
+	resp, err := cli.SayHello(&helloworld.HelloRequest{Name: "world"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/helloworld/greeter_server/main.go
+++ b/examples/helloworld/greeter_server/main.go
@@ -20,9 +20,8 @@ type server struct{}
 
 // SayHello is an implementation of the SayHello method from the definition of
 // the Greeter service.
-func (s *server) SayHello(ctx context.Context, req helloworld.HelloRequest) (resp helloworld.HelloReply, err error) {
-	resp.Message = "Hello " + req.Name
-	return
+func (s *server) SayHello(ctx context.Context, req *helloworld.HelloRequest) (resp *helloworld.HelloReply, err error) {
+	return &helloworld.HelloReply{Message: "Hello " + req.Name}, nil
 }
 
 func main() {

--- a/examples/helloworld/greeter_server/main_test.go
+++ b/examples/helloworld/greeter_server/main_test.go
@@ -38,7 +38,7 @@ func TestBasic(t *testing.T) {
 	cli := helloworld.NewGreeterClient(nc)
 
 	// Contact the server and print out its response.
-	resp, err := cli.SayHello(helloworld.HelloRequest{Name: "world"})
+	resp, err := cli.SayHello(&helloworld.HelloRequest{Name: "world"})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Finally implement passing pointer args.

It solves #40 , and fulfil the same goal as #39 (which was closed a while ago by @T-J-L).

